### PR TITLE
Laravel Translatable support

### DIFF
--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -12,6 +12,11 @@ class Settings extends Model
     public $incrementing = false;
     public $timestamps = false;
     public $fillable = ['key', 'value'];
+    
+    public function setValueAttribute($value)
+    {
+        $this->attributes['value'] = is_array($value) ? json_encode($value) : $value;
+    }
 
     public function getValueAttribute($value)
     {


### PR DESCRIPTION
Added support for Laravel Translatable from Spatie: https://github.com/spatie/laravel-translatable, in my case I'm using this Nova integration: https://github.com/mrmonat/nova-translatable. An example to get this working:

```
\OptimistDigital\NovaSettings\NovaSettings::setSettingsFields([
    Translatable::make('Name'),
    Translatable::make('Description'),
], function ($key, $value) {
    return in_array($key, ['name', 'description']) ? json_decode($value) : $value;
});
```

Fixes: https://github.com/optimistdigital/nova-settings/issues/5