### PR TITLE
Add type="submit" to save settings button

### DIFF
--- a/resources/js/views/Settings.vue
+++ b/resources/js/views/Settings.vue
@@ -16,7 +16,7 @@
 
       <!-- Update Button -->
       <div class="flex items-center">
-        <progress-button class="ml-auto" @click.native="update" :disabled="isUpdating" :processing="isUpdating">
+        <progress-button type="submit" class="ml-auto" @click.native="update" :disabled="isUpdating" :processing="isUpdating">
           {{ __('novaSettings.saveButtonText') }}
         </progress-button>
       </div>


### PR DESCRIPTION
Hi, thanks for making such a great package. 

This is UX improvement. When you hit `Enter` key, while focused on in any of the fields, it will save the settings.