### PR TITLE
Add optional default value, if setting with given key was not found.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ If you want the value of the setting to be formatted before it's returned, pass 
 
 Call `nova_get_settings()` to get all the settings formated as a regular array. If you pass in `$keys` as an array, it will return only the keys listed.
 
-#### nova_get_setting(\$key)
+#### nova_get_setting(\$key, \$default = null)
 
-To get a single setting's value, call `nova_get_setting('some_setting_key')`. It will return either a value or null if there's no setting with such key.
+To get a single setting's value, call `nova_get_setting('some_setting_key')`. It will return either a value or null if there's no setting with such key. 
+
+You can also pass default value as a second argument `nova_get_setting('some_setting_key', 'default_value')`, which will be returned, if no setting was found with given key.
 
 ## Configuration
 

--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -67,10 +67,10 @@ class NovaSettings extends Tool
         return self::$casts;
     }
 
-    public static function getSetting($settingKey)
+    public static function getSetting($settingKey, $default = null)
     {
         if (isset(static::$cache[$settingKey])) return static::$cache[$settingKey];
-        static::$cache[$settingKey] = Settings::find($settingKey)->value ?? null;
+        static::$cache[$settingKey] = Settings::find($settingKey)->value ?? $default;
         return static::$cache[$settingKey];
     }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,8 +11,8 @@ if (!function_exists('nova_get_settings')) {
 }
 
 if (!function_exists('nova_get_setting')) {
-    function nova_get_setting($settingKey)
+    function nova_get_setting($settingKey, $default = null)
     {
-        return NovaSettings::getSetting($settingKey);
+        return NovaSettings::getSetting($settingKey, $default);
     }
 }


### PR DESCRIPTION
It would be nice to have an ability to pass optional default value to the `nova_get_setting` helper function, just like, `cache()`, `session()` and other methods have in Laravel. 