### PR TITLE
Fixes duplicate panels.

### DIFF
--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -132,7 +132,7 @@ class SettingsController extends Controller
         $method = $this->fieldsMethod($request);
 
         return with(
-            collect(array_values($this->{$method}($request, $request->get('path', 'general'))))->whereInstanceOf(Panel::class)->values(),
+            collect(array_values($this->{$method}($request, $request->get('path', 'general'))))->whereInstanceOf(Panel::class)->unique('name')->values(),
             function ($panels) use ($label) {
                 return $panels->when($panels->where('name', $label)->isEmpty(), function ($panels) use ($label) {
                     return $panels->prepend((new Panel($label))->withToolbar());


### PR DESCRIPTION
I was testing the new pages feature of the library and I noticed that if you add panels with the same name, but different fields it combines the fields, but also duplicates the panels. This fixes the panel duplication.

```
NovaSettings::addSettingsFields([
    new Panel('Wrong', [
        Text::make('A', 'a'),
    ])
], [], 'Test');

NovaSettings::addSettingsFields([
    new Panel('Wrong', [
        Text::make('B', 'b'),
    ])
], [], 'Test');

NovaSettings::addSettingsFields([
    new Panel('Correct', [
        Text::make('C', 'c'),
    ])
], [], 'Test');
```

Before:
<img width="1792" alt="Screen Shot 2020-12-01 at 5 02 59 PM" src="https://user-images.githubusercontent.com/11588575/100802963-4e177c00-33f8-11eb-8d05-e4434c28503f.png">

After:
<img width="1792" alt="Screen Shot 2020-12-01 at 5 03 45 PM" src="https://user-images.githubusercontent.com/11588575/100803382-13621380-33f9-11eb-8ff6-9299545b295b.png">

