### PR TITLE
Using getValueForKey method instead of find in getSetting.

### DIFF
--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -103,7 +103,7 @@ class NovaSettings extends Tool
     public static function getSetting($settingKey, $default = null)
     {
         if (isset(static::$cache[$settingKey])) return static::$cache[$settingKey];
-        static::$cache[$settingKey] = static::getSettingsModel()::find($settingKey)->value ?? $default;
+        static::$cache[$settingKey] = static::getSettingsModel()::getValueForKey($settingKey) ?? $default;
         return static::$cache[$settingKey];
     }
 


### PR DESCRIPTION
By using `getValueForKey` method from the `getSetting`, it can be flexible to add a cache layer in the custom Setting Model by overriding `getValueForKey` method like this:

```
// CustomSettingModel.php

public static function getValueForKey($key)
{
    return Cache::rememberForever(self::getCacheKey($key), function () use ($key) {
        $setting = static::where('key', $key)->get()->first();

        return isset($setting) ? $setting->value : null;
    });
}
```
