### PR TITLE
feat: hide sidebar menu config

### DIFF
--- a/config/nova-settings.php
+++ b/config/nova-settings.php
@@ -26,4 +26,9 @@ return [
     'models' => [
         'settings' => \OptimistDigital\NovaSettings\Models\Settings::class,
     ],
+
+    /**
+     * Hide the sidebar menu
+     */
+    'sidebar_menu' => true
 ];

--- a/config/nova-settings.php
+++ b/config/nova-settings.php
@@ -28,7 +28,7 @@ return [
     ],
 
     /**
-     * Hide the sidebar menu
+     * Show the sidebar menu
      */
     'sidebar_menu' => true
 ];

--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -26,10 +26,12 @@ class NovaSettings extends Tool
 
     public function renderNavigation()
     {
-        return view('nova-settings::navigation', [
-            'fields' => static::$fields,
-            'basePath' => config('nova-settings.base_path', 'nova-settings'),
-        ]);
+        if (config('nova-settings.sidebar_menu')) {
+            return view('nova-settings::navigation', [
+                'fields' => static::$fields,
+                'basePath' => config('nova-settings.base_path', 'nova-settings'),
+            ]);
+        }
     }
 
     public static function getSettingsTableName(): string


### PR DESCRIPTION
Sometimes we need to manage the sidebar to not show the setting menu e.g (we're use the external package that manage the sidebar we cannot replace the current setting menu).

this feature possible to more flexible to toggle the menu