### PR TITLE
Allow assigning default values with requesting multiple settings

### DIFF
--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -86,9 +86,9 @@ class NovaSettings extends Tool
         return static::getStore()->getSetting($settingKey, $default);
     }
 
-    public static function getSettings(array $settingKeys = null)
+    public static function getSettings(array $settingKeys = null, array $defaults = [])
     {
-        return static::getStore()->getSettings($settingKeys);
+        return static::getStore()->getSettings($settingKeys, $defaults);
     }
 
     public static function setSettingValue($settingKey, $value = null)

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,9 +3,9 @@
 use OptimistDigital\NovaSettings\NovaSettings;
 
 if (!function_exists('nova_get_settings')) {
-    function nova_get_settings($settingKeys = null)
+    function nova_get_settings($settingKeys = null, $defaults = [])
     {
-        return NovaSettings::getSettings($settingKeys);
+        return NovaSettings::getSettings($settingKeys, $defaults);
     }
 }
 


### PR DESCRIPTION
Implements feature that allows passing an array of default values to nova_get_settings.

```php
// With default values
$settings = nova_get_settings(['non_existant_key'], ['non_existant_key' => 'default']);
$settings === ['non_existant_key' => 'default'];
```