### PR TITLE
Change way of fetching single key to fix extendability

### DIFF
--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -26,7 +26,7 @@ class SettingsController extends Controller
 
         $addResolveCallback = function (&$field) {
             if (!empty($field->attribute)) {
-                $setting = NovaSettings::getSettingsModel()::findOrNew($field->attribute);
+                $setting = NovaSettings::getSettingsModel()::firstOrNew(['key' => $field->attribute]);
                 $field->resolve([$field->attribute => isset($setting) ? $setting->value : '']);
             }
 


### PR DESCRIPTION
Hi there

This change makes it possible to fetch single settings by explicitly providing the column by which it should be searched for, instead of relying on the key column being the primary id.

This change is necessary to extend the model with a default ID column for it be referenceable by e.x. the activity log package from spatie. simple change, huge effect.

Thx
Best
Dimitri