### PR TITLE
Allow authorization check for nova resource with custom model

### DIFF
--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -50,7 +50,7 @@ class NovaSettings extends Tool
     public static function getAuthorizations($key = null)
     {
         $request = request();
-        $fakeResource = new \OptimistDigital\NovaSettings\Nova\Resources\Settings(new Settings());
+        $fakeResource = new \OptimistDigital\NovaSettings\Nova\Resources\Settings(NovaSettings::getSettingsModel()::make());
 
         $authorizations = [
             'authorizedToView' => $fakeResource->authorizedToView($request),


### PR DESCRIPTION
Currently authorization is limited to the included settings model. To make it work with nova and a custom model, the auth check should be done with the custom settings model.