### PR TITLE
fix: update default parameter from null to empty array in getSettings…

### DIFF
--- a/src/NovaSettings.php
+++ b/src/NovaSettings.php
@@ -119,7 +119,7 @@ class NovaSettings extends Tool
         return static::getStore()->getSetting($settingKey, $default);
     }
 
-    public static function getSettings(array $settingKeys = null, array $defaults = [])
+    public static function getSettings(array $settingKeys = [], array $defaults = [])
     {
         return static::getStore()->getSettings($settingKeys, $defaults);
     }

--- a/src/NovaSettingsStore.php
+++ b/src/NovaSettingsStore.php
@@ -72,7 +72,7 @@ abstract class NovaSettingsStore
         return $settingValue;
     }
 
-    public function getSettings(array $settingKeys = null, array $defaults = [])
+    public function getSettings(array $settingKeys = [], array $defaults = [])
     {
         if (!empty($settingKeys)) {
             $cached = $this->getCached($settingKeys);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,7 +3,7 @@
 use Outl1ne\NovaSettings\NovaSettings;
 
 if (!function_exists('nova_get_settings')) {
-    function nova_get_settings($settingKeys = null, $defaults = [])
+    function nova_get_settings($settingKeys = [], $defaults = [])
     {
         return NovaSettings::getSettings($settingKeys, $defaults);
     }


### PR DESCRIPTION
This pull request includes changes to the `NovaSettings` functionality to ensure that the `getSettings` method handles default values more consistently. The most important changes include modifying the method signatures in several files to use empty arrays as default parameters instead of `null`.

Consistency improvements to `getSettings` method:

* [`src/NovaSettings.php`](diffhunk://#diff-a55652c01a1c61827dd0f4020e29e626b26cc7badc1e76312771fa298fd51143L122-R122): Changed the `getSettings` method to use an empty array as the default value for `settingKeys` instead of `null`.
* [`src/NovaSettingsStore.php`](diffhunk://#diff-c80345f75880ceba068dfa5f7253b6bad0019aecec3e948501260b91e57787cbL75-R75): Updated the `getSettings` method to use an empty array as the default value for `settingKeys` instead of `null`.
* [`src/helpers.php`](diffhunk://#diff-7827dcf8c28ba9d97397f03b4ca75c132540f5c377e253fbc47ef064a373ce73L6-R6): Modified the `nova_get_settings` function to use an empty array as the default value for `settingKeys` instead of `null`.